### PR TITLE
bug(#4) : kill 명령어전 docker compose down 코드 추가

### DIFF
--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -47,6 +47,13 @@ title() {
 
 title "HLab-Web Development Server"
 
+if docker ps -q -f "name=hlab-web-dev" > /dev/null 2>&1; then
+  warn "개발 서버가 이미 실행 중입니다. 기존 컨테이너를 종료 중..."
+  docker compose -f ./docker/docker-compose.dev.yml down
+  sleep 2
+  success "기존 컨테이너 종료 완료"
+fi
+
 if lsof -i :3000 > /dev/null 2>&1; then
   warn "포트 3000이 이미 사용 중입니다. 기존 프로세스 종료 중..."
   PIDS=$(lsof -t -i :3000)

--- a/scripts/run_dev.sh
+++ b/scripts/run_dev.sh
@@ -47,7 +47,7 @@ title() {
 
 title "HLab-Web Development Server"
 
-if docker ps -q -f "name=hlab-web-dev" > /dev/null 2>&1; then
+if [ -n "$(docker ps -q --filter 'name=hlab-web-dev')" ]; then
   warn "개발 서버가 이미 실행 중입니다. 기존 컨테이너를 종료 중..."
   docker compose -f ./docker/docker-compose.dev.yml down
   sleep 2

--- a/scripts/run_prod.sh
+++ b/scripts/run_prod.sh
@@ -58,6 +58,13 @@ fi
 
 step "서버 시작..."
 
+if docker ps -q -f "name=hlab-web-prod" > /dev/null 2>&1; then
+  warn "프로덕션 서버가 이미 실행 중입니다. 기존 컨테이너를 종료 중..."
+  docker compose -f ./docker/docker-compose.prod.yml down
+  sleep 2
+  success "기존 컨테이너 종료 완료"
+fi
+
 if lsof -i :3000 > /dev/null 2>&1; then
   warn "포트 3000이 이미 사용 중입니다. 기존 프로세스 종료 중..."
   PIDS=$(lsof -t -i :3000)

--- a/scripts/run_prod.sh
+++ b/scripts/run_prod.sh
@@ -58,7 +58,7 @@ fi
 
 step "서버 시작..."
 
-if docker ps -q -f "name=hlab-web-prod" > /dev/null 2>&1; then
+if [ -n "$(docker ps -q --filter 'name=hlab-web-dev')" ]; then
   warn "프로덕션 서버가 이미 실행 중입니다. 기존 컨테이너를 종료 중..."
   docker compose -f ./docker/docker-compose.prod.yml down
   sleep 2


### PR DESCRIPTION
## ✨ 작업 내용
- 기존 run_prod.sh파일에 docker compose down 코드 추가
- 기존 run_dev.sh 파일에 docker compose down 코드 추가

## 🎯 작업 목적
run_prod.sh, run_dev.sh 파일에 포트 충돌 방지를 위한 코드가 docker 자체를 중단 시켜 포트 충돌 이후 docker의 동작 부재 현상 해결

## 🧩 설계 의사결정
docker compose 파일을 포트 충돌 확인 전에 down 시킬 경우 docker에서 포트 충돌이 아는건 아닌 상황이므로 kill 명령어로 해당 프로세스 자체가 종료해도 된다고 판단함.

## 🔍 리스크 및 고려 사항
해당 배포 서버에서 다른 현재 프로젝트와 다른 docker compose 파일이 3000 포트로 올라올 경우 현재 코드로 종료 불가. 위와 같은 docker 동작 부제 현상이 생길수 있음.

## 🧪 테스트 및 검증 결과
### run_dev.sh 파일 테스트 사진
<img width="378" height="692" alt="image" src="https://github.com/user-attachments/assets/8cd304f8-e895-4367-8dcf-25419150e42c" />

### run_prod.sh 파일 테스트 사진
<img width="382" height="710" alt="image" src="https://github.com/user-attachments/assets/ff468d52-87ad-4dc0-9561-b7058567f20a" />


## 🔗 관련 이슈
#4 